### PR TITLE
Fix: Changing the Lifecycle owner to fragment view lifecycle.

### DIFF
--- a/GuessTheWordDataBinding/app/src/main/java/com/example/android/guesstheword/screens/game/GameFragment.kt
+++ b/GuessTheWordDataBinding/app/src/main/java/com/example/android/guesstheword/screens/game/GameFragment.kt
@@ -57,12 +57,12 @@ class GameFragment : Fragment() {
         // to all the data in the VieWModel
         binding.gameViewModel = viewModel
 
-        // Specify the current activity as the lifecycle owner of the binding.
+        // Specify the fragment view as the lifecycle owner of the binding.
         // This is used so that the binding can observe LiveData updates
-        binding.lifecycleOwner = this
+        binding.lifecycleOwner = viewLifecycleOwner
 
         // Observer for the Game finished event
-        viewModel.eventGameFinish.observe(this, Observer<Boolean> { hasFinished ->
+        viewModel.eventGameFinish.observe(viewLifecycleOwner, Observer<Boolean> { hasFinished ->
             if (hasFinished) gameFinished()
         })
 

--- a/GuessTheWordDataBinding/app/src/main/java/com/example/android/guesstheword/screens/score/ScoreFragment.kt
+++ b/GuessTheWordDataBinding/app/src/main/java/com/example/android/guesstheword/screens/score/ScoreFragment.kt
@@ -55,12 +55,12 @@ class ScoreFragment : Fragment() {
                 .get(ScoreViewModel::class.java)
         binding.scoreViewModel = viewModel
 
-        // Specify the current activity as the lifecycle owner of the binding.
+        // Specify the fragment view as the lifecycle owner of the binding.
         // This is used so that the binding can observe LiveData updates
-        binding.lifecycleOwner = this
+        binding.lifecycleOwner = viewLifecycleOwner
 
         // Navigates back to game when button is pressed
-        viewModel.eventPlayAgain.observe(this, Observer { playAgain ->
+        viewModel.eventPlayAgain.observe(viewLifecycleOwner, Observer { playAgain ->
             if (playAgain) {
                 findNavController().navigate(ScoreFragmentDirections.actionRestart())
                 viewModel.onPlayAgainComplete()

--- a/GuessTheWordLiveData/app/src/main/java/com/example/android/guesstheword/screens/game/GameFragment.kt
+++ b/GuessTheWordLiveData/app/src/main/java/com/example/android/guesstheword/screens/game/GameFragment.kt
@@ -54,17 +54,17 @@ class GameFragment : Fragment() {
         viewModel = ViewModelProviders.of(this).get(GameViewModel::class.java)
 
         /** Setting up LiveData observation relationship **/
-        viewModel.word.observe(this, Observer { newWord ->
+        viewModel.word.observe(viewLifecycleOwner, Observer { newWord ->
             binding.wordText.text = newWord
         })
 
-        viewModel.score.observe(this, Observer { newScore ->
+        viewModel.score.observe(viewLifecycleOwner, Observer { newScore ->
             binding.scoreText.text = newScore.toString()
 
         })
 
         // Observer for the Game finished event
-        viewModel.eventGameFinish.observe(this, Observer<Boolean> { hasFinished ->
+        viewModel.eventGameFinish.observe(viewLifecycleOwner, Observer<Boolean> { hasFinished ->
             if (hasFinished) gameFinished()
         })
 

--- a/GuessTheWordLiveData/app/src/main/java/com/example/android/guesstheword/screens/score/ScoreFragment.kt
+++ b/GuessTheWordLiveData/app/src/main/java/com/example/android/guesstheword/screens/score/ScoreFragment.kt
@@ -56,14 +56,14 @@ class ScoreFragment : Fragment() {
                 .get(ScoreViewModel::class.java)
 
         // Add observer for score
-        viewModel.score.observe(this, Observer { newScore ->
+        viewModel.score.observe(viewLifecycleOwner, Observer { newScore ->
             binding.scoreText.text = newScore.toString()
         })
 
         binding.playAgainButton.setOnClickListener { viewModel.onPlayAgain() }
 
         // Navigates back to game when button is pressed
-        viewModel.eventPlayAgain.observe(this, Observer { playAgain ->
+        viewModel.eventPlayAgain.observe(viewLifecycleOwner, Observer { playAgain ->
             if (playAgain) {
                 findNavController().navigate(ScoreFragmentDirections.actionRestart())
                 viewModel.onPlayAgainComplete()

--- a/GuessTheWordTransformation/app/src/main/java/com/example/android/guesstheword/screens/game/GameFragment.kt
+++ b/GuessTheWordTransformation/app/src/main/java/com/example/android/guesstheword/screens/game/GameFragment.kt
@@ -57,9 +57,9 @@ class GameFragment : Fragment() {
         // to all the data in the VieWModel
         binding.gameViewModel = viewModel
 
-        // Specify the current activity as the lifecycle owner of the binding.
+        // Specify the fragment view as the lifecycle owner of the binding.
         // This is used so that the binding can observe LiveData updates
-        binding.lifecycleOwner = this
+        binding.lifecycleOwner = viewLifecycleOwner
 
 
         // Observer for the Game finished event

--- a/GuessTheWordTransformation/app/src/main/java/com/example/android/guesstheword/screens/score/ScoreFragment.kt
+++ b/GuessTheWordTransformation/app/src/main/java/com/example/android/guesstheword/screens/score/ScoreFragment.kt
@@ -55,9 +55,9 @@ class ScoreFragment : Fragment() {
                 .get(ScoreViewModel::class.java)
         binding.scoreViewModel = viewModel
 
-        // Specify the current activity as the lifecycle owner of the binding.
+        // Specify the fragment view as the lifecycle owner of the binding.
         // This is used so that the binding can observe LiveData updates
-        binding.lifecycleOwner = this
+        binding.lifecycleOwner = viewLifecycleOwner
 
         // Navigates back to game when button is pressed
         viewModel.eventPlayAgain.observe(this, Observer { playAgain ->


### PR DESCRIPTION
Changing the Lifecycle owner to fragment view lifecycle instead of fragment lifecycle for Databinding and Livedata.

Ref issue: https://github.com/google-developer-training/android-kotlin-fundamentals-apps/issues/15