### PR TITLE
fix: Typo 'actiivty' in DevBytesRepository and DevBytesWorkManager

### DIFF
--- a/DevBytesRepository/app/src/main/java/com/example/android/devbyteviewer/viewmodels/DevByteViewModel.kt
+++ b/DevBytesRepository/app/src/main/java/com/example/android/devbyteviewer/viewmodels/DevByteViewModel.kt
@@ -37,7 +37,7 @@ import java.io.IOException
  * results after the new Fragment or Activity is available.
  *
  * @param application The application that this viewmodel is attached to, it's safe to hold a
- * reference to applications across rotation since Application is never recreated during actiivty
+ * reference to applications across rotation since Application is never recreated during activity
  * or fragment lifecycle events.
  */
 class DevByteViewModel(application: Application) : AndroidViewModel(application) {

--- a/DevBytesWorkManager/app/src/main/java/com/example/android/devbyteviewer/viewmodels/DevByteViewModel.kt
+++ b/DevBytesWorkManager/app/src/main/java/com/example/android/devbyteviewer/viewmodels/DevByteViewModel.kt
@@ -37,7 +37,7 @@ import java.io.IOException
  * results after the new Fragment or Activity is available.
  *
  * @param application The application that this viewmodel is attached to, it's safe to hold a
- * reference to applications across rotation since Application is never recreated during actiivty
+ * reference to applications across rotation since Application is never recreated during activity
  * or fragment lifecycle events.
  */
 class DevByteViewModel(application: Application) : AndroidViewModel(application) {


### PR DESCRIPTION
**Describe the problem**
Typo 'actiivty' present instead of 'activity' in DevBytesRepository and DevBytesWorkManager projects. This has been fixed.

**In which lesson and step of the codelab can this issue be found?**
Lesson 9.2 + step 3 and 9

Fixes #263