### PR TITLE
Fixed Issue with GDGFinder throwing 404 and crashing

### DIFF
--- a/GDGFinderFinal/app/src/main/java/com/example/android/gdgfinder/network/GdgApiService.kt
+++ b/GDGFinderFinal/app/src/main/java/com/example/android/gdgfinder/network/GdgApiService.kt
@@ -26,25 +26,24 @@ import retrofit2.http.GET
 
 // The alternative URL is for a server with a recent snapshot. If you are having problems
 // with the given URL (app crashing), use the alternative.
-private const val BASE_URL = "https://developers.google.com/community/gdg/groups/"
+private const val BASE_URL = "https://gdg.community.dev/api/"
 
 interface GdgApiService {
-    @GET("directory.json")
-
+    @GET("chapter_region?chapters=true")
     fun getChapters():
     // The Coroutine Call Adapter allows us to return a Deferred, a Job with a result
-            Deferred<GdgResponse>
+            Deferred<List<GdgRegion>>
 }
 
 private val moshi = Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
-        .build()
+    .add(KotlinJsonAdapterFactory())
+    .build()
 
 private val retrofit = Retrofit.Builder()
-        .addConverterFactory(MoshiConverterFactory.create(moshi))
-        .addCallAdapterFactory(CoroutineCallAdapterFactory())
-        .baseUrl(BASE_URL)
-        .build()
+    .addConverterFactory(MoshiConverterFactory.create(moshi))
+    .addCallAdapterFactory(CoroutineCallAdapterFactory())
+    .baseUrl(BASE_URL)
+    .build()
 
 object GdgApi {
     val retrofitService: GdgApiService by lazy { retrofit.create(GdgApiService::class.java) }

--- a/GDGFinderFinal/app/src/main/java/com/example/android/gdgfinder/network/GdgApiService.kt
+++ b/GDGFinderFinal/app/src/main/java/com/example/android/gdgfinder/network/GdgApiService.kt
@@ -36,14 +36,14 @@ interface GdgApiService {
 }
 
 private val moshi = Moshi.Builder()
-    .add(KotlinJsonAdapterFactory())
-    .build()
+        .add(KotlinJsonAdapterFactory())
+        .build()
 
 private val retrofit = Retrofit.Builder()
-    .addConverterFactory(MoshiConverterFactory.create(moshi))
-    .addCallAdapterFactory(CoroutineCallAdapterFactory())
-    .baseUrl(BASE_URL)
-    .build()
+        .addConverterFactory(MoshiConverterFactory.create(moshi))
+        .addCallAdapterFactory(CoroutineCallAdapterFactory())
+        .baseUrl(BASE_URL)
+        .build()
 
 object GdgApi {
     val retrofitService: GdgApiService by lazy { retrofit.create(GdgApiService::class.java) }

--- a/GDGFinderFinal/app/src/main/java/com/example/android/gdgfinder/network/GdgChapter.kt
+++ b/GDGFinderFinal/app/src/main/java/com/example/android/gdgfinder/network/GdgChapter.kt
@@ -23,30 +23,21 @@ import kotlinx.android.parcel.Parcelize
 
 @Parcelize
 data class GdgChapter(
-    @Json(name = "chapter_name") val name: String,
-    @Json(name = "cityarea") val city: String,
+    val active: Boolean,
+    @Json(name = "title") val title: String,
+    @Json(name = "city") val city: String,
     val country: String,
-    val region: String,
-    val website: String,
-    val geo: LatLong
- ): Parcelable
-
-@Parcelize
-data class LatLong(
-    val lat: Double,
-    @Json(name = "lng")
-    val long: Double
-) : Parcelable
-
-@Parcelize
-data class GdgResponse(
-        @Json(name = "filters_") val filters: Filter,
-        @Json(name = "data") val chapters: List<GdgChapter>
+    val state: String,
+    val url: String,
+    val latitude: Double,
+    val longitude: Double
 ): Parcelable
 
 @Parcelize
-data class Filter(
-        @Json(name = "region") val regions: List<String>
+data class GdgRegion(
+    @Json(name = "title") val title: String,
+    @Json(name = "chapters" +
+            "") val chapters: List<GdgChapter>
 ): Parcelable
 
 //"chapter_name": "GDG Bordj Bou-Arréridj",

--- a/GDGFinderFinal/app/src/main/java/com/example/android/gdgfinder/search/GdgChapterRepository.kt
+++ b/GDGFinderFinal/app/src/main/java/com/example/android/gdgfinder/search/GdgChapterRepository.kt
@@ -176,14 +176,17 @@ class GdgChapterRepository(gdgApiService: GdgApiService) {
             }
 
             /**
-             * Creates a
+             * Creates List that contains all the chapters from the regions
+             *
+             * @param regions list of regions returned from request
+             * @return chapters list of chapters
              */
-            private fun getChapters(response: List<GdgRegion>): List<GdgChapter> {
-                var chapters1 : List<GdgChapter> = listOf()
-                for (region in response){
-                    chapters1 = chapters1 + region.chapters
+            private fun getChapters(regions: List<GdgRegion>): List<GdgChapter> {
+                var chapters : List<GdgChapter> = listOf()
+                for (region in regions){
+                    chapters = chapters + region.chapters
                 }
-                return chapters1
+                return chapters
             }
 
             /**

--- a/GDGFinderFinal/app/src/main/java/com/example/android/gdgfinder/search/GdgListFragment.kt
+++ b/GDGFinderFinal/app/src/main/java/com/example/android/gdgfinder/search/GdgListFragment.kt
@@ -59,7 +59,7 @@ class GdgListFragment : Fragment() {
         binding.viewModel = viewModel
 
         val adapter = GdgListAdapter(GdgClickListener { chapter ->
-            val destination = Uri.parse(chapter.website)
+            val destination = Uri.parse(chapter.url)
             startActivity(Intent(Intent.ACTION_VIEW, destination))
         })
 

--- a/GDGFinderFinal/app/src/main/res/layout/list_item.xml
+++ b/GDGFinderFinal/app/src/main/res/layout/list_item.xml
@@ -56,7 +56,7 @@
             android:layout_marginStart="@dimen/spacing_normal"
             android:layout_marginEnd="@dimen/spacing_normal"
             android:gravity="center_vertical"
-            android:text="@{chapter.name}"
+            android:text="@{chapter.title}"
             android:textAppearance="?textAppearanceHeadline6"
             app:layout_constraintBottom_toBottomOf="@+id/gdg_image"
             app:layout_constraintEnd_toEndOf="parent"

--- a/GDGFinderMaterial/app/src/main/java/com/example/android/gdgfinder/network/GdgApiService.kt
+++ b/GDGFinderMaterial/app/src/main/java/com/example/android/gdgfinder/network/GdgApiService.kt
@@ -26,25 +26,24 @@ import retrofit2.http.GET
 
 // The alternative URL is for a server with a recent snapshot. If you are having problems
 // with the given URL (app crashing), use the alternative.
-private const val BASE_URL = "https://developers.google.com/community/gdg/groups/"
+private const val BASE_URL = "https://gdg.community.dev/api/"
 
 interface GdgApiService {
-    @GET("directory.json")
-
+    @GET("chapter_region?chapters=true")
     fun getChapters():
     // The Coroutine Call Adapter allows us to return a Deferred, a Job with a result
-            Deferred<GdgResponse>
+            Deferred<List<GdgRegion>>
 }
 
 private val moshi = Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
-        .build()
+    .add(KotlinJsonAdapterFactory())
+    .build()
 
 private val retrofit = Retrofit.Builder()
-        .addConverterFactory(MoshiConverterFactory.create(moshi))
-        .addCallAdapterFactory(CoroutineCallAdapterFactory())
-        .baseUrl(BASE_URL)
-        .build()
+    .addConverterFactory(MoshiConverterFactory.create(moshi))
+    .addCallAdapterFactory(CoroutineCallAdapterFactory())
+    .baseUrl(BASE_URL)
+    .build()
 
 object GdgApi {
     val retrofitService: GdgApiService by lazy { retrofit.create(GdgApiService::class.java) }

--- a/GDGFinderMaterial/app/src/main/java/com/example/android/gdgfinder/network/GdgApiService.kt
+++ b/GDGFinderMaterial/app/src/main/java/com/example/android/gdgfinder/network/GdgApiService.kt
@@ -36,14 +36,14 @@ interface GdgApiService {
 }
 
 private val moshi = Moshi.Builder()
-    .add(KotlinJsonAdapterFactory())
-    .build()
+        .add(KotlinJsonAdapterFactory())
+        .build()
 
 private val retrofit = Retrofit.Builder()
-    .addConverterFactory(MoshiConverterFactory.create(moshi))
-    .addCallAdapterFactory(CoroutineCallAdapterFactory())
-    .baseUrl(BASE_URL)
-    .build()
+        .addConverterFactory(MoshiConverterFactory.create(moshi))
+        .addCallAdapterFactory(CoroutineCallAdapterFactory())
+        .baseUrl(BASE_URL)
+        .build()
 
 object GdgApi {
     val retrofitService: GdgApiService by lazy { retrofit.create(GdgApiService::class.java) }

--- a/GDGFinderMaterial/app/src/main/java/com/example/android/gdgfinder/network/GdgChapter.kt
+++ b/GDGFinderMaterial/app/src/main/java/com/example/android/gdgfinder/network/GdgChapter.kt
@@ -21,33 +21,23 @@ import com.squareup.moshi.Json
 import kotlinx.android.parcel.Parcelize
 
 
-
 @Parcelize
 data class GdgChapter(
-    @Json(name = "chapter_name") val name: String,
-    @Json(name = "cityarea") val city: String,
-    val country: String,
-    val region: String,
-    val website: String,
-    val geo: LatLong
- ): Parcelable
-
-@Parcelize
-data class LatLong(
-    val lat: Double,
-    @Json(name = "lng")
-    val long: Double
-) : Parcelable
-
-@Parcelize
-data class GdgResponse(
-        @Json(name = "filters_") val filters: Filter,
-        @Json(name = "data") val chapters: List<GdgChapter>
+        val active: Boolean,
+        @Json(name = "title") val title: String,
+        @Json(name = "city") val city: String,
+        val country: String,
+        val state: String,
+        val url: String,
+        val latitude: Double,
+        val longitude: Double
 ): Parcelable
 
 @Parcelize
-data class Filter(
-        @Json(name = "region") val regions: List<String>
+data class GdgRegion(
+        @Json(name = "title") val title: String,
+        @Json(name = "chapters" +
+                "") val chapters: List<GdgChapter>
 ): Parcelable
 
 //"chapter_name": "GDG Bordj Bou-Arréridj",

--- a/GDGFinderMaterial/app/src/main/java/com/example/android/gdgfinder/search/GdgChapterRepository.kt
+++ b/GDGFinderMaterial/app/src/main/java/com/example/android/gdgfinder/search/GdgChapterRepository.kt
@@ -176,14 +176,17 @@ class GdgChapterRepository(gdgApiService: GdgApiService) {
             }
 
             /**
-             * Creates a
+             * Creates List that contains all the chapters from the regions
+             *
+             * @param regions list of regions returned from request
+             * @return chapters list of chapters
              */
-            private fun getChapters(response: List<GdgRegion>): List<GdgChapter> {
-                var chapters1 : List<GdgChapter> = listOf()
-                for (region in response){
-                    chapters1 = chapters1 + region.chapters
+            private fun getChapters(regions: List<GdgRegion>): List<GdgChapter> {
+                var chapters : List<GdgChapter> = listOf()
+                for (region in regions){
+                    chapters = chapters + region.chapters
                 }
-                return chapters1
+                return chapters
             }
 
             /**

--- a/GDGFinderMaterial/app/src/main/java/com/example/android/gdgfinder/search/GdgChapterRepository.kt
+++ b/GDGFinderMaterial/app/src/main/java/com/example/android/gdgfinder/search/GdgChapterRepository.kt
@@ -1,3 +1,4 @@
+package com.example.android.gdgfinder.search
 /*
  * Copyright 2019, The Android Open Source Project
  *
@@ -14,13 +15,11 @@
  * limitations under the License.
  */
 
-package com.example.android.gdgfinder.search
 
 import android.location.Location
 import com.example.android.gdgfinder.network.GdgApiService
 import com.example.android.gdgfinder.network.GdgChapter
-import com.example.android.gdgfinder.network.GdgResponse
-import com.example.android.gdgfinder.network.LatLong
+import com.example.android.gdgfinder.network.GdgRegion
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -160,21 +159,32 @@ class GdgChapterRepository(gdgApiService: GdgApiService) {
              * @param response the response to sort
              * @param location the location to sort by, if null the data will not be sorted.
              */
-            suspend fun from(response: GdgResponse, location: Location?): SortedData {
+            suspend fun from(response: List<GdgRegion>, location: Location?): SortedData {
                 return withContext(Dispatchers.Default) {
                     // this sorting is too expensive to do on the main thread, so do thread confinement here.
-                    val chapters: List<GdgChapter> = response.chapters.sortByDistanceFrom(location)
+
+                    val chapters: List<GdgChapter> = getChapters(response).sortByDistanceFrom(location)
                     // use distinctBy which will maintain the input order - this will have the effect of making
                     // a filter list sorted by the distance from the current location
-                    val filters: List<String> = chapters.map { it.region } .distinctBy { it }
+                    val filters: List<String> = chapters.map { it.country } .distinctBy { it }
                     // group the chapters by region so that filter queries don't require any work
-                    val chaptersByRegion: Map<String, List<GdgChapter>> = chapters.groupBy { it.region }
+                    val chaptersByRegion: Map<String, List<GdgChapter>> = chapters.groupBy { it.country }
                     // return the sorted result
                     SortedData(chapters, filters, chaptersByRegion)
                 }
 
             }
 
+            /**
+             * Creates a
+             */
+            private fun getChapters(response: List<GdgRegion>): List<GdgChapter> {
+                var chapters1 : List<GdgChapter> = listOf()
+                for (region in response){
+                    chapters1 = chapters1 + region.chapters
+                }
+                return chapters1
+            }
 
             /**
              * Sort a list of GdgChapter by their distance from the specified location.
@@ -184,15 +194,15 @@ class GdgChapterRepository(gdgApiService: GdgApiService) {
             private fun List<GdgChapter>.sortByDistanceFrom(currentLocation: Location?): List<GdgChapter> {
                 currentLocation ?: return this
 
-                return sortedBy { distanceBetween(it.geo, currentLocation)}
+                return sortedBy { distanceBetween(it, currentLocation)}
             }
 
             /**
              * Calculate the distance (in meters) between a LatLong and a Location.
              */
-            private fun distanceBetween(start: LatLong, currentLocation: Location): Float {
+            private fun distanceBetween(start: GdgChapter, currentLocation: Location): Float {
                 val results = FloatArray(3)
-                Location.distanceBetween(start.lat, start.long, currentLocation.latitude, currentLocation.longitude, results)
+                Location.distanceBetween(start.latitude, start.longitude, currentLocation.latitude, currentLocation.longitude, results)
                 return results[0]
             }
         }

--- a/GDGFinderMaterial/app/src/main/java/com/example/android/gdgfinder/search/GdgListFragment.kt
+++ b/GDGFinderMaterial/app/src/main/java/com/example/android/gdgfinder/search/GdgListFragment.kt
@@ -57,7 +57,7 @@ class GdgListFragment : Fragment() {
         binding.viewModel = viewModel
 
         val adapter = GdgListAdapter(GdgClickListener { chapter ->
-            val destination = Uri.parse(chapter.website)
+            val destination = Uri.parse(chapter.url)
             startActivity(Intent(Intent.ACTION_VIEW, destination))
         })
 

--- a/GDGFinderMaterial/app/src/main/res/layout/list_item.xml
+++ b/GDGFinderMaterial/app/src/main/res/layout/list_item.xml
@@ -57,7 +57,7 @@
             android:layout_marginStart="@dimen/spacing_normal"
             android:layout_marginEnd="@dimen/spacing_normal"
             android:gravity="center_vertical"
-            android:text="@{chapter.name}"
+            android:text="@{chapter.title}"
             android:textAppearance="?textAppearanceHeadline6"
             app:layout_constraintBottom_toBottomOf="@+id/gdg_image"
             app:layout_constraintEnd_toEndOf="parent"

--- a/GDGFinderStyles/app/src/main/java/com/example/android/gdgfinder/network/GdgApiService.kt
+++ b/GDGFinderStyles/app/src/main/java/com/example/android/gdgfinder/network/GdgApiService.kt
@@ -26,25 +26,24 @@ import retrofit2.http.GET
 
 // The alternative URL is for a server with a recent snapshot. If you are having problems
 // with the given URL (app crashing), use the alternative.
-private const val BASE_URL = "https://developers.google.com/community/gdg/groups/"
+private const val BASE_URL = "https://gdg.community.dev/api/"
 
 interface GdgApiService {
-    @GET("directory.json")
-
+    @GET("chapter_region?chapters=true")
     fun getChapters():
     // The Coroutine Call Adapter allows us to return a Deferred, a Job with a result
-            Deferred<GdgResponse>
+            Deferred<List<GdgRegion>>
 }
 
 private val moshi = Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
-        .build()
+    .add(KotlinJsonAdapterFactory())
+    .build()
 
 private val retrofit = Retrofit.Builder()
-        .addConverterFactory(MoshiConverterFactory.create(moshi))
-        .addCallAdapterFactory(CoroutineCallAdapterFactory())
-        .baseUrl(BASE_URL)
-        .build()
+    .addConverterFactory(MoshiConverterFactory.create(moshi))
+    .addCallAdapterFactory(CoroutineCallAdapterFactory())
+    .baseUrl(BASE_URL)
+    .build()
 
 object GdgApi {
     val retrofitService: GdgApiService by lazy { retrofit.create(GdgApiService::class.java) }

--- a/GDGFinderStyles/app/src/main/java/com/example/android/gdgfinder/network/GdgApiService.kt
+++ b/GDGFinderStyles/app/src/main/java/com/example/android/gdgfinder/network/GdgApiService.kt
@@ -36,14 +36,14 @@ interface GdgApiService {
 }
 
 private val moshi = Moshi.Builder()
-    .add(KotlinJsonAdapterFactory())
-    .build()
+        .add(KotlinJsonAdapterFactory())
+        .build()
 
 private val retrofit = Retrofit.Builder()
-    .addConverterFactory(MoshiConverterFactory.create(moshi))
-    .addCallAdapterFactory(CoroutineCallAdapterFactory())
-    .baseUrl(BASE_URL)
-    .build()
+        .addConverterFactory(MoshiConverterFactory.create(moshi))
+        .addCallAdapterFactory(CoroutineCallAdapterFactory())
+        .baseUrl(BASE_URL)
+        .build()
 
 object GdgApi {
     val retrofitService: GdgApiService by lazy { retrofit.create(GdgApiService::class.java) }

--- a/GDGFinderStyles/app/src/main/java/com/example/android/gdgfinder/network/GdgChapter.kt
+++ b/GDGFinderStyles/app/src/main/java/com/example/android/gdgfinder/network/GdgChapter.kt
@@ -21,33 +21,24 @@ import com.squareup.moshi.Json
 import kotlinx.android.parcel.Parcelize
 
 
-
 @Parcelize
 data class GdgChapter(
-    @Json(name = "chapter_name") val name: String,
-    @Json(name = "cityarea") val city: String,
+    val active: Boolean,
+    @Json(name = "title") val title: String,
+    @Json(name = "city") val city: String,
     val country: String,
-    val region: String,
-    val website: String,
-    val geo: LatLong
- ): Parcelable
-
-@Parcelize
-data class LatLong(
-    val lat: Double,
-    @Json(name = "lng")
-    val long: Double
-) : Parcelable
-
-@Parcelize
-data class GdgResponse(
-        @Json(name = "filters_") val filters: Filter,
-        @Json(name = "data") val chapters: List<GdgChapter>
+    val regions: String,
+    val state: String,
+    val url: String,
+    val latitude: Double,
+    val longitude: Double
 ): Parcelable
 
 @Parcelize
-data class Filter(
-        @Json(name = "region") val regions: List<String>
+data class GdgRegion(
+    @Json(name = "title") val title: String,
+    @Json(name = "chapters" +
+            "") val chapters: List<GdgChapter>
 ): Parcelable
 
 //"chapter_name": "GDG Bordj Bou-Arréridj",

--- a/GDGFinderStyles/app/src/main/java/com/example/android/gdgfinder/search/GdgChapterRepository.kt
+++ b/GDGFinderStyles/app/src/main/java/com/example/android/gdgfinder/search/GdgChapterRepository.kt
@@ -176,14 +176,17 @@ class GdgChapterRepository(gdgApiService: GdgApiService) {
             }
 
             /**
-             * Creates a
+             * Creates List that contains all the chapters from the regions
+             *
+             * @param regions list of regions returned from request
+             * @return chapters list of chapters
              */
-            private fun getChapters(response: List<GdgRegion>): List<GdgChapter> {
-                var chapters1 : List<GdgChapter> = listOf()
-                for (region in response){
-                    chapters1 = chapters1 + region.chapters
+            private fun getChapters(regions: List<GdgRegion>): List<GdgChapter> {
+                var chapters : List<GdgChapter> = listOf()
+                for (region in regions){
+                    chapters = chapters + region.chapters
                 }
-                return chapters1
+                return chapters
             }
 
             /**

--- a/GDGFinderStyles/app/src/main/java/com/example/android/gdgfinder/search/GdgChapterRepository.kt
+++ b/GDGFinderStyles/app/src/main/java/com/example/android/gdgfinder/search/GdgChapterRepository.kt
@@ -1,3 +1,4 @@
+package com.example.android.gdgfinder.search
 /*
  * Copyright 2019, The Android Open Source Project
  *
@@ -14,13 +15,11 @@
  * limitations under the License.
  */
 
-package com.example.android.gdgfinder.search
 
 import android.location.Location
 import com.example.android.gdgfinder.network.GdgApiService
 import com.example.android.gdgfinder.network.GdgChapter
-import com.example.android.gdgfinder.network.GdgResponse
-import com.example.android.gdgfinder.network.LatLong
+import com.example.android.gdgfinder.network.GdgRegion
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -160,21 +159,32 @@ class GdgChapterRepository(gdgApiService: GdgApiService) {
              * @param response the response to sort
              * @param location the location to sort by, if null the data will not be sorted.
              */
-            suspend fun from(response: GdgResponse, location: Location?): SortedData {
+            suspend fun from(response: List<GdgRegion>, location: Location?): SortedData {
                 return withContext(Dispatchers.Default) {
                     // this sorting is too expensive to do on the main thread, so do thread confinement here.
-                    val chapters: List<GdgChapter> = response.chapters.sortByDistanceFrom(location)
+
+                    val chapters: List<GdgChapter> = getChapters(response).sortByDistanceFrom(location)
                     // use distinctBy which will maintain the input order - this will have the effect of making
                     // a filter list sorted by the distance from the current location
-                    val filters: List<String> = chapters.map { it.region } .distinctBy { it }
+                    val filters: List<String> = chapters.map { it.country } .distinctBy { it }
                     // group the chapters by region so that filter queries don't require any work
-                    val chaptersByRegion: Map<String, List<GdgChapter>> = chapters.groupBy { it.region }
+                    val chaptersByRegion: Map<String, List<GdgChapter>> = chapters.groupBy { it.country }
                     // return the sorted result
                     SortedData(chapters, filters, chaptersByRegion)
                 }
 
             }
 
+            /**
+             * Creates a
+             */
+            private fun getChapters(response: List<GdgRegion>): List<GdgChapter> {
+                var chapters1 : List<GdgChapter> = listOf()
+                for (region in response){
+                    chapters1 = chapters1 + region.chapters
+                }
+                return chapters1
+            }
 
             /**
              * Sort a list of GdgChapter by their distance from the specified location.
@@ -184,15 +194,15 @@ class GdgChapterRepository(gdgApiService: GdgApiService) {
             private fun List<GdgChapter>.sortByDistanceFrom(currentLocation: Location?): List<GdgChapter> {
                 currentLocation ?: return this
 
-                return sortedBy { distanceBetween(it.geo, currentLocation)}
+                return sortedBy { distanceBetween(it, currentLocation)}
             }
 
             /**
              * Calculate the distance (in meters) between a LatLong and a Location.
              */
-            private fun distanceBetween(start: LatLong, currentLocation: Location): Float {
+            private fun distanceBetween(start: GdgChapter, currentLocation: Location): Float {
                 val results = FloatArray(3)
-                Location.distanceBetween(start.lat, start.long, currentLocation.latitude, currentLocation.longitude, results)
+                Location.distanceBetween(start.latitude, start.longitude, currentLocation.latitude, currentLocation.longitude, results)
                 return results[0]
             }
         }

--- a/GDGFinderStyles/app/src/main/java/com/example/android/gdgfinder/search/GdgListFragment.kt
+++ b/GDGFinderStyles/app/src/main/java/com/example/android/gdgfinder/search/GdgListFragment.kt
@@ -57,7 +57,7 @@ class GdgListFragment : Fragment() {
         binding.viewModel = viewModel
 
         val adapter = GdgListAdapter(GdgClickListener { chapter ->
-            val destination = Uri.parse(chapter.website)
+            val destination = Uri.parse(chapter.url)
             startActivity(Intent(Intent.ACTION_VIEW, destination))
         })
 

--- a/GDGFinderStyles/app/src/main/res/layout/list_item.xml
+++ b/GDGFinderStyles/app/src/main/res/layout/list_item.xml
@@ -56,7 +56,7 @@
             android:layout_marginStart="16dp"
             android:layout_marginEnd="16dp"
             android:gravity="center_vertical"
-            android:text="@{chapter.name}"
+            android:text="@{chapter.title}"
             android:textAppearance="?textAppearanceHeadline6"
             app:layout_constraintBottom_toBottomOf="@+id/gdg_image"
             app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
This was due to the url changing for the JSON file as well as the structure changing.

Current issue is that the region information is no longer stored in the Chapter object so currently the filter is based off Country.

- [ ] Code Standard need checking

- [ ] Filter Functionaility needs to be  looked to more closely to see if original functionality can be maintained

- [ ] Add Example JSON

If accepted this needs to be merged to Starter apps as well as the Udemy course repo.