### PR TITLE
[refactor] Initialize ViewModel and NavArgs with lazy delegates

### DIFF
--- a/GuessTheWordViewModel/app/build.gradle
+++ b/GuessTheWordViewModel/app/build.gradle
@@ -39,6 +39,14 @@ android {
     buildFeatures {
         dataBinding true
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
+    }
 }
 
 dependencies {

--- a/GuessTheWordViewModel/app/src/main/java/com/example/android/guesstheword/screens/game/GameFragment.kt
+++ b/GuessTheWordViewModel/app/src/main/java/com/example/android/guesstheword/screens/game/GameFragment.kt
@@ -24,6 +24,7 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.NavHostFragment
 import com.example.android.guesstheword.R
@@ -36,7 +37,7 @@ class GameFragment : Fragment() {
 
     private lateinit var binding: GameFragmentBinding
 
-    private lateinit var viewModel: GameViewModel
+    private val viewModel: GameViewModel by viewModels()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {
@@ -49,9 +50,6 @@ class GameFragment : Fragment() {
                 false
         )
         Log.i("GameFragment", "Called ViewModelProvider.get")
-
-        // Get the viewModel
-        viewModel = ViewModelProvider(this).get(GameViewModel::class.java)
 
         binding.correctButton.setOnClickListener { onCorrect() }
         binding.skipButton.setOnClickListener { onSkip() }

--- a/GuessTheWordViewModel/app/src/main/java/com/example/android/guesstheword/screens/score/ScoreFragment.kt
+++ b/GuessTheWordViewModel/app/src/main/java/com/example/android/guesstheword/screens/score/ScoreFragment.kt
@@ -22,6 +22,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.navArgs
 import com.example.android.guesstheword.R
@@ -31,9 +32,11 @@ import com.example.android.guesstheword.databinding.ScoreFragmentBinding
  * Fragment where the final score is shown, after the game is over
  */
 class ScoreFragment : Fragment() {
+    private val args: ScoreFragmentArgs by navArgs()
 
-    private lateinit var viewModel: ScoreViewModel
-    private lateinit var viewModelFactory: ScoreViewModelFactory
+    private val viewModel: ScoreViewModel by viewModels{
+        ScoreViewModelFactory(args.score)
+    }
 
     override fun onCreateView(
             inflater: LayoutInflater,
@@ -48,10 +51,6 @@ class ScoreFragment : Fragment() {
                 container,
                 false
         )
-
-        viewModelFactory = ScoreViewModelFactory(ScoreFragmentArgs.fromBundle(arguments!!).score)
-        viewModel = ViewModelProvider(this, viewModelFactory)
-                .get(ScoreViewModel::class.java)
 
         binding.scoreText.text = viewModel.score.toString()
 


### PR DESCRIPTION
Fixes issue #421. This code is more idiomatic and uses KTX delegates.

[Using Java 1.8 was necessary](https://stackoverflow.com/questions/48988778/cannot-inline-bytecode-built-with-jvm-target-1-8-into-bytecode-that-is-being-bui) otherwise it shows `Cannot inline bytecode built with JVM target 1.8 into bytecode that is being built with JVM target 1.6` error.